### PR TITLE
Sort all columns by descending order

### DIFF
--- a/sacferals/adminprofile.php
+++ b/sacferals/adminprofile.php
@@ -541,7 +541,7 @@
 			{
 				$RecordNumber1 = $_GET['RecordNumber'];
 								
-				$query = "select * from VolunteerForm  where RecordNumber = ".$RecordNumber1."";
+				$query = "select * from VolunteerForm  where RecordNumber = ".$RecordNumber1." order by RecordNumber desc";
 				$result = mysqli_query($link, $query);
 				$row = mysqli_fetch_row($result);
 				list($RecordNumber, $Comments, $VolunteerStatus, $DateAndTime, $FullName, $Address, $Email, $Phone1, $Phone2, $PreferedContact, $contactemail, $contactphone1, $contactphone2, $TypeOfWork, $transporting, $helptrap, $helpeducate, $usingphone, $helpingclinic, $other, $OtherTasks, $PastWorkExp, $UnknownNameColumn, $ResponseDate, $EmailResponse, $BEATId, $BEATName, $BEATGeneralArea, $BEATZipCodes, $BEATTrainDate, $BEATMembers, $BEATMembersPhone,$BEATMemberEmails, $BEATType, $BEATNotes, $BEATStatus, $TriageBEATNotes, $DateActivated, $WorkshopAttended, $WorkshopDate) = $row;
@@ -564,7 +564,7 @@
 				}
 				else{
 					//regular search
-					$query = "select * from VolunteerForm order by $sort";
+					$query = "select * from VolunteerForm order by $sort desc";
 					$result = mysqli_query($link, $query);
 				}
 				
@@ -601,44 +601,44 @@
 							{
 								print "
 								<th><a href='adminprofile.php?sort=RecordNumber'>ID</a></th>
-								<th><a href='adminprofile.php?sort='Comments'>Triage Comments</a></th>
-								<th><a href='adminprofile.php?sort='VolunteerStatus'>Volunteer Status</a></th>
-								<th><a href='adminprofile.php?sort='DateAndTime'>Date Submitted</a></th>
-								<th><a href='adminprofile.php?sort='WorkshopAttended'>Workshop</a></th>
-								<th><a href='adminprofile.php?sort='WorkshopDate'>Workshop Date</a></th>
-								<th><a href='adminprofile.php?sort='DateActivated'>Date Activated</a></th>
-								<th><a href='adminprofile.php?sort='FullName'>Full Name</a></th>
-								<th><a href='adminprofile.php?sort='Address'>Complete Address</a></th>
-								<th><a href='adminprofile.php?sort='Email'>Email</a></th>
-								<th><a href='adminprofile.php?sort='Phone1'>Phone1</a></th>
-								<th><a href='adminprofile.php?sort='Phone2'>Phone2</a></th>
-								<th><a href='adminprofile.php?sort='PreferedContact'>Prefered Contact</a></th>
-								<th><a href='adminprofile.php?sort='contactemail'>Prefered Email</a></th>
-								<th><a href='adminprofile.php?sort='contactphone1'>Prefered Phone1</a></th>
-								<th><a href='adminprofile.php?sort='contactphone2'>Prefered Phone2</a></th>
-								<th><a href='adminprofile.php?sort='TypeOfWork'>Type Of Work</a></th>
-								<th><a href='adminprofile.php?sort='transporting'>Transporter</a></th>
-								<th><a href='adminprofile.php?sort='helptrap'>Trapper</a></th>
-								<th><a href='adminprofile.php?sort='helpeducate'>Educator</a></th>
-								<th><a href='adminprofile.php?sort='usingphone'>Triage</a></th>
-								<th><a href='adminprofile.php?sort='other'>Other</a></th>
-								<th><a href='adminprofile.php?sort='OtherTasks'>Other Tasks Details</a></th>
-								<th><a href='adminprofile.php?sort='PastWorkExp'>Past Experience</a></th>
-								<th><a href='adminprofile.php?sort='UnknownNameColumn'>Unknown</a></th>
-								<th><a href='adminprofile.php?sort='ResponseDate'>Response Date</a></th>
-								<th><a href='adminprofile.php?sort='EmailResponse'>Email Response</a></th>
-								<th><a href='adminprofile.php?sort='BEATId'>BEAT ID</a></th>					
-								<th><a href='adminprofile.php?sort='BEATName'>BEAT Name</a></th>
-								<th><a href='adminprofile.php?sort='BEATGeneralArea'>BEAT Gen. Area</a></th>
-								<th><a href='adminprofile.php?sort='BEATZipCodes'>BEAT Zip Code</a></th>
-								<th><a href='adminprofile.php?sort='BEATTrainDate'>BEAT Train Date</a></th>
-								<th><a href='adminprofile.php?sort='BEATMembers'>BEAT Member</a></th>
-								<th><a href='adminprofile.php?sort='BEATMembersPhone'>BEAT Member Phone</a></th>
-								<th><a href='adminprofile.php?sort='BEATMemberEmails'>BEAT Member Email</a></th>
-								<th><a href='adminprofile.php?sort='BEATType'>BEAT Type</a></th>
-								<th><a href='adminprofile.php?sort='BEATNotes'>BEAT Notes</a></th>
-								<th><a href='adminprofile.php?sort='BEATStatus'>BEAT Status</a></th>					
-								<th><a href='adminprofile.php?sort='TriageBEATNotes'>BEAT Triage Notes</a></th>
+								<th><a href='adminprofile.php?sort=Comments'>Triage Comments</a></th>
+								<th><a href='adminprofile.php?sort=VolunteerStatus'>Volunteer Status</a></th>
+								<th><a href='adminprofile.php?sort=DateAndTime'>Date Submitted</a></th>
+								<th><a href='adminprofile.php?sort=WorkshopAttended'>Workshop</a></th>
+								<th><a href='adminprofile.php?sort=WorkshopDate'>Workshop Date</a></th>
+								<th><a href='adminprofile.php?sort=DateActivated'>Date Activated</a></th>
+								<th><a href='adminprofile.php?sort=FullName'>Full Name</a></th>
+								<th><a href='adminprofile.php?sort=Address'>Complete Address</a></th>
+								<th><a href='adminprofile.php?sort=Email'>Email</a></th>
+								<th><a href='adminprofile.php?sort=Phone1'>Phone1</a></th>
+								<th><a href='adminprofile.php?sort=Phone2'>Phone2</a></th>
+								<th><a href='adminprofile.php?sort=PreferedContact'>Prefered Contact</a></th>
+								<th><a href='adminprofile.php?sort=contactemail'>Prefered Email</a></th>
+								<th><a href='adminprofile.php?sort=contactphone1'>Prefered Phone1</a></th>
+								<th><a href='adminprofile.php?sort=contactphone2'>Prefered Phone2</a></th>
+								<th><a href='adminprofile.php?sort=TypeOfWork'>Type Of Work</a></th>
+								<th><a href='adminprofile.php?sort=transporting'>Transporter</a></th>
+								<th><a href='adminprofile.php?sort=helptrap'>Trapper</a></th>
+								<th><a href='adminprofile.php?sort=helpeducate'>Educator</a></th>
+								<th><a href='adminprofile.php?sort=usingphone'>Triage</a></th>
+								<th><a href='adminprofile.php?sort=other'>Other</a></th>
+								<th><a href='adminprofile.php?sort=OtherTasks'>Other Tasks Details</a></th>
+								<th><a href='adminprofile.php?sort=PastWorkExp'>Past Experience</a></th>
+								<th><a href='adminprofile.php?sort=UnknownNameColumn'>Unknown</a></th>
+								<th><a href='adminprofile.php?sort=ResponseDate'>Response Date</a></th>
+								<th><a href='adminprofile.php?sort=EmailResponse'>Email Response</a></th>
+								<th><a href='adminprofile.php?sort=BEATId'>BEAT ID</a></th>					
+								<th><a href='adminprofile.php?sort=BEATName'>BEAT Name</a></th>
+								<th><a href='adminprofile.php?sort=BEATGeneralArea'>BEAT Gen. Area</a></th>
+								<th><a href='adminprofile.php?sort=BEATZipCodes'>BEAT Zip Code</a></th>
+								<th><a href='adminprofile.php?sort=BEATTrainDate'>BEAT Train Date</a></th>
+								<th><a href='adminprofile.php?sort=BEATMembers'>BEAT Member</a></th>
+								<th><a href='adminprofile.php?sort=BEATMembersPhone'>BEAT Member Phone</a></th>
+								<th><a href='adminprofile.php?sort=BEATMemberEmails'>BEAT Member Email</a></th>
+								<th><a href='adminprofile.php?sort=BEATType'>BEAT Type</a></th>
+								<th><a href='adminprofile.php?sort=BEATNotes'>BEAT Notes</a></th>
+								<th><a href='adminprofile.php?sort=BEATStatus'>BEAT Status</a></th>					
+								<th><a href='adminprofile.php?sort=TriageBEATNotes'>BEAT Triage Notes</a></th>
 							</tr>
 						</thead>
 						";
@@ -1061,7 +1061,7 @@
 			}
 			else{
 				//regular search
-				$query = "select * from VolunteerForm order by $sort";
+				$query = "select * from VolunteerForm order by $sort desc";
 				$result = mysqli_query($link, $query);
 			}
 			$_SESSION['volunteertotalrecords']=mysqli_num_rows($result);
@@ -1100,45 +1100,45 @@
 								else
 								{
 									print "
-								<th><a href='adminprofile.php?sort='RecordNumber'>ID</a></th>
-								<th><a href='adminprofile.php?sort='Comments'>Triage Comments</a></th>
-								<th><a href='adminprofile.php?sort='VolunteerStatus'>Volunteer Status</a></th>
-								<th><a href='adminprofile.php?sort='DateAndTime'>Date Submitted</a></th>
-								<th><a href='adminprofile.php?sort='WorkshopAttended'>Workshop</a></th>
-								<th><a href='adminprofile.php?sort='WorkshopDate'>Workshop Date</a></th>
-								<th><a href='adminprofile.php?sort='DateActivated'>Date Actived</a></th>
-								<th><a href='adminprofile.php?sort='FullName'>Full Name</a></th>
-								<th><a href='adminprofile.php?sort='Address'>Complete Address</a></th>
-								<th><a href='adminprofile.php?sort='Email'>Email</a></th>
-								<th><a href='adminprofile.php?sort='Phone1'>Phone1</a></th>
-								<th><a href='adminprofile.php?sort='Phone2'>Phone2</a></th>
-								<th><a href='adminprofile.php?sort='PreferedContact'>Prefered Contact</a></th>
-								<th><a href='adminprofile.php?sort='contactemail'>Prefered Email</a></th>
-								<th><a href='adminprofile.php?sort='contactphone1'>Prefered Phone1</a></th>
-								<th><a href='adminprofile.php?sort='contactphone2'>Prefered Phone2</a></th>
-								<th><a href='adminprofile.php?sort='TypeOfWork'>Type Of Work</a></th>
-								<th><a href='adminprofile.php?sort='transporting'>Transporter</a></th>
-								<th><a href='adminprofile.php?sort='helptrap'>Trapper</a></th>
-								<th><a href='adminprofile.php?sort='helpeducate'>Educator</a></th>
-								<th><a href='adminprofile.php?sort='usingphone'>Triage</a></th>
-								<th><a href='adminprofile.php?sort='other'>Other</a></th>
-								<th><a href='adminprofile.php?sort='OtherTasks'>Other Tasks Details</a></th>
-								<th><a href='adminprofile.php?sort='PastWorkExp'>Past Experience</a></th>
-								<th><a href='adminprofile.php?sort='UnknownNameColumn'>Unknown</a></th>
-								<th><a href='adminprofile.php?sort='ResponseDate'>Response Date</a></th>
-								<th><a href='adminprofile.php?sort='EmailResponse'>Email Response</a></th>
-								<th><a href='adminprofile.php?sort='BEATId'>BEAT ID</a></th>					
-								<th><a href='adminprofile.php?sort='BEATName'>BEAT Name</a></th>
-								<th><a href='adminprofile.php?sort='BEATGeneralArea'>BEAT Gen. Area</a></th>
-								<th><a href='adminprofile.php?sort='BEATZipCodes'>BEAT Zip Code</a></th>
-								<th><a href='adminprofile.php?sort='BEATTrainDate'>BEAT Train Date</a></th>
-								<th><a href='adminprofile.php?sort='BEATMembers'>BEAT Member</a></th>
-								<th><a href='adminprofile.php?sort='BEATMembersPhone'>BEAT Member Phone</a></th>
-								<th><a href='adminprofile.php?sort='BEATMemberEmails'>BEAT Member Email</a></th>
-								<th><a href='adminprofile.php?sort='BEATType'>BEAT Type</a></th>
-								<th><a href='adminprofile.php?sort='BEATNotes'>BEAT Notes</a></th>
-								<th><a href='adminprofile.php?sort='BEATStatus'>BEAT Status</a></th>					
-								<th><a href='adminprofile.php?sort='TriageBEATNotes'>BEAT Triage Notes</a></th>								
+								<th><a href='adminprofile.php?sort=RecordNumber'>ID</a></th>
+								<th><a href='adminprofile.php?sort=Comments'>Triage Comments</a></th>
+								<th><a href='adminprofile.php?sort=VolunteerStatus'>Volunteer Status</a></th>
+								<th><a href='adminprofile.php?sort=DateAndTime'>Date Submitted</a></th>
+								<th><a href='adminprofile.php?sort=WorkshopAttended'>Workshop</a></th>
+								<th><a href='adminprofile.php?sort=WorkshopDate'>Workshop Date</a></th>
+								<th><a href='adminprofile.php?sort=DateActivated'>Date Actived</a></th>
+								<th><a href='adminprofile.php?sort=FullName'>Full Name</a></th>
+								<th><a href='adminprofile.php?sort=Address'>Complete Address</a></th>
+								<th><a href='adminprofile.php?sort=Email'>Email</a></th>
+								<th><a href='adminprofile.php?sort=Phone1'>Phone1</a></th>
+								<th><a href='adminprofile.php?sort=Phone2'>Phone2</a></th>
+								<th><a href='adminprofile.php?sort=PreferedContact'>Prefered Contact</a></th>
+								<th><a href='adminprofile.php?sort=contactemail'>Prefered Email</a></th>
+								<th><a href='adminprofile.php?sort=contactphone1'>Prefered Phone1</a></th>
+								<th><a href='adminprofile.php?sort=contactphone2'>Prefered Phone2</a></th>
+								<th><a href='adminprofile.php?sort=TypeOfWork'>Type Of Work</a></th>
+								<th><a href='adminprofile.php?sort=transporting'>Transporter</a></th>
+								<th><a href='adminprofile.php?sort=helptrap'>Trapper</a></th>
+								<th><a href='adminprofile.php?sort=helpeducate'>Educator</a></th>
+								<th><a href='adminprofile.php?sort=usingphone'>Triage</a></th>
+								<th><a href='adminprofile.php?sort=other'>Other</a></th>
+								<th><a href='adminprofile.php?sort=OtherTasks'>Other Tasks Details</a></th>
+								<th><a href='adminprofile.php?sort=PastWorkExp'>Past Experience</a></th>
+								<th><a href='adminprofile.php?sort=UnknownNameColumn'>Unknown</a></th>
+								<th><a href='adminprofile.php?sort=ResponseDate'>Response Date</a></th>
+								<th><a href='adminprofile.php?sort=EmailResponse'>Email Response</a></th>
+								<th><a href='adminprofile.php?sort=BEATId'>BEAT ID</a></th>					
+								<th><a href='adminprofile.php?sort=BEATName'>BEAT Name</a></th>
+								<th><a href='adminprofile.php?sort=BEATGeneralArea'>BEAT Gen. Area</a></th>
+								<th><a href='adminprofile.php?sort=BEATZipCodes'>BEAT Zip Code</a></th>
+								<th><a href='adminprofile.php?sort=BEATTrainDate'>BEAT Train Date</a></th>
+								<th><a href='adminprofile.php?sort=BEATMembers'>BEAT Member</a></th>
+								<th><a href='adminprofile.php?sort=BEATMembersPhone'>BEAT Member Phone</a></th>
+								<th><a href='adminprofile.php?sort=BEATMemberEmails'>BEAT Member Email</a></th>
+								<th><a href='adminprofile.php?sort=BEATType'>BEAT Type</a></th>
+								<th><a href='adminprofile.php?sort=BEATNotes'>BEAT Notes</a></th>
+								<th><a href='adminprofile.php?sort=BEATStatus'>BEAT Status</a></th>					
+								<th><a href='adminprofile.php?sort=TriageBEATNotes'>BEAT Triage Notes</a></th>								
 						</tr>";
 								}
 					print"

--- a/sacferals/search.php
+++ b/sacferals/search.php
@@ -551,7 +551,7 @@
 			if(isset($_GET['editrow']))
 			{
 				$RecordNumber1 = $_GET['RecordNumber'];
-				$query = "select * from ReportColonyForm  where RecordNumber = ".$RecordNumber1."";
+				$query = "select * from ReportColonyForm  where RecordNumber = ".$RecordNumber1." order by RecordNumber desc";
 				$result = mysqli_query($link, $query);
 				$row = mysqli_fetch_row($result);
 				list($Comments1, $Responder, $Status, $RecordNumber, $DateAndTime, $FeedIfReturned, $FullName, $Email, $Phone1, $Phone2, $ColonyAddress,
@@ -571,7 +571,7 @@
 				}
 				else{
 					//regular search
-					$query = "select * from ReportColonyForm order by $sort";
+					$query = "select * from ReportColonyForm order by $sort desc";
 					$result = mysqli_query($link, $query);
 				}
 				
@@ -910,8 +910,6 @@
 
 						$query=rtrim($query," and ");
 
-						//print $query;
-
 						$result = mysqli_query($link, $query);
 
 						if(mysqli_num_rows($result) == 0)
@@ -948,7 +946,7 @@
 					{
 
 
-						$query = "select * from ReportColonyForm where RecordNumber='$RecordNumber1'";
+						$query = "select * from ReportColonyForm where RecordNumber='$RecordNumber1' order by RecordNumber desc";
 						$result = mysqli_query($link, $query);
 
 						if(mysqli_num_rows($result) == 1)//if query does nothing, then update
@@ -1043,7 +1041,7 @@
 			}
 			else{
 				//regular search
-				$query = "select * from ReportColonyForm order by $sort";
+				$query = "select * from ReportColonyForm order by $sort desc";
 				$result = mysqli_query($link, $query);
 			}
 			$_SESSION['totalrecords']=mysqli_num_rows($result);
@@ -1081,13 +1079,12 @@
 							if($thString != '')
 								{
 									print $thString;
-									print"</tr>";
+									print"</tr></thead>";
 									//print"(editRow not set header)";
 								}
 								else
 								{
 									print "
-
 							<th><a href='search.php?sort=RecordNumber'>ID</a></th>
 							<th><a href='search.php?sort=DateAndTime'>Date/Time</a></th>
 							<th><a href='search.php?sort=Responder'>Responder</a></th>
@@ -1123,14 +1120,13 @@
 							<th><a href='search.php?sort=Lng'>Longitude</a></th>
 
 						</tr>";
-								}
+						}
 					print"
 					</thead>
 
 					<tbody>";
 
 					//while the next row (set by query) exists?
-
 					while($row = mysqli_fetch_row($result))
 					{
 						list($Comments1, $Responder, $Status, $RecordNumber, $DateAndTime, $FeedIfReturned, $FullName, $Email, $Phone1, $Phone2, $ColonyAddress,

--- a/sacferals/volunteerlist.php
+++ b/sacferals/volunteerlist.php
@@ -558,7 +558,7 @@
 			{
 				$RecordNumber1 = $_GET['RecordNumber'];
 								
-				$query = "select * from VolunteerForm  where RecordNumber = ".$RecordNumber1."";
+				$query = "select * from VolunteerForm  where RecordNumber = ".$RecordNumber1." order by RecordNumber desc";
 				$result = mysqli_query($link, $query);
 				$row = mysqli_fetch_row($result);
 				list($RecordNumber, $Comments, $VolunteerStatus, $DateAndTime, $FullName, $Address, $Email, $Phone1, $Phone2, $PreferedContact, $contactemail, $contactphone1, $contactphone2, $TypeOfWork, $transporting, $helptrap, $helpeducate, $usingphone, $helpingclinic, $other, $OtherTasks, $PastWorkExp, $UnknownNameColumn, $ResponseDate, $EmailResponse, $BEATId, $BEATName, $BEATGeneralArea, $BEATZipCodes, $BEATTrainDate, $BEATMembers, $BEATMembersPhone,$BEATMemberEmails, $BEATType, $BEATNotes, $BEATStatus, $TriageBEATNotes, $DateActivated, $WorkshopAttended, $WorkshopDate) = $row;
@@ -581,7 +581,7 @@
 				}
 				else{
 					//regular search
-					$query = "select * from VolunteerForm order by $sort";
+					$query = "select * from VolunteerForm order by $sort desc";
 					$result = mysqli_query($link, $query);
 				}
 				
@@ -616,49 +616,50 @@
 							{
 								print "
 								<th><a href='volunteerlist.php?sort=RecordNumber'>ID</a></th>
-								<th><a href='volunteerlist.php?sort='Comments'>Triage Comments</a></th>
-								<th><a href='volunteerlist.php?sort='VolunteerStatus'>Volunteer Status</a></th>
-								<th><a href='volunteerlist.php?sort='DateAndTime'>Date Submitted</a></th>
-								<th><a href='volunteerlist.php?sort='WorkshopAttended'>Workshop</a></th>
-								<th><a href='volunteerlist.php?sort='WorkshopDate'>Workshop Date</a></th>
-								<th><a href='volunteerlist.php?sort='DateActivated'>Date Activated</a></th>
-								<th><a href='volunteerlist.php?sort='FullName'>Full Name</a></th>
-								<th><a href='volunteerlist.php?sort='Address'>Complete Address</a></th>
-								<th><a href='volunteerlist.php?sort='Email'>Email</a></th>
-								<th><a href='volunteerlist.php?sort='Phone1'>Phone1</a></th>
-								<th><a href='volunteerlist.php?sort='Phone2'>Phone2</a></th>
-								<th><a href='volunteerlist.php?sort='PreferedContact'>Prefered Contact</a></th>
-								<th><a href='volunteerlist.php?sort='contactemail'>Prefered Email</a></th>
-								<th><a href='volunteerlist.php?sort='contactphone1'>Prefered Phone1</a></th>
-								<th><a href='volunteerlist.php?sort='contactphone2'>Prefered Phone2</a></th>
-								<th><a href='volunteerlist.php?sort='TypeOfWork'>Type Of Work</a></th>
-								<th><a href='volunteerlist.php?sort='transporting'>Transporter</a></th>
-								<th><a href='volunteerlist.php?sort='helptrap'>Trapper</a></th>
-								<th><a href='volunteerlist.php?sort='helpeducate'>Educator</a></th>
-								<th><a href='volunteerlist.php?sort='usingphone'>Triage</a></th>
-								<th><a href='volunteerlist.php?sort='other'>Other</a></th>
-								<th><a href='volunteerlist.php?sort='OtherTasks'>Other Tasks Details</a></th>
-								<th><a href='volunteerlist.php?sort='PastWorkExp'>Past Experience</a></th>
-								<th><a href='volunteerlist.php?sort='UnknownNameColumn'>Unknown</a></th>
-								<th><a href='volunteerlist.php?sort='ResponseDate'>Response Date</a></th>
-								<th><a href='volunteerlist.php?sort='EmailResponse'>Email Response</a></th>
-								<th><a href='volunteerlist.php?sort='BEATId'>BEAT ID</a></th>					
-								<th><a href='volunteerlist.php?sort='BEATName'>BEAT Name</a></th>
-								<th><a href='volunteerlist.php?sort='BEATGeneralArea'>BEAT Gen. Area</a></th>
-								<th><a href='volunteerlist.php?sort='BEATZipCodes'>BEAT Zip Code</a></th>
-								<th><a href='volunteerlist.php?sort='BEATTrainDate'>BEAT Train Date</a></th>
-								<th><a href='volunteerlist.php?sort='BEATMembers'>BEAT Member</a></th>
-								<th><a href='volunteerlist.php?sort='BEATMembersPhone'>BEAT Member Phone</a></th>
-								<th><a href='volunteerlist.php?sort='BEATMemberEmails'>BEAT Member Email</a></th>
-								<th><a href='volunteerlist.php?sort='BEATType'>BEAT Type</a></th>
-								<th><a href='volunteerlist.php?sort='BEATNotes'>BEAT Notes</a></th>
-								<th><a href='volunteerlist.php?sort='BEATStatus'>BEAT Status</a></th>					
-								<th><a href='volunteerlist.php?sort='TriageBEATNotes'>BEAT Triage Notes</a></th>
-							</tr>
-						</thead>
-						";
+								<th><a href='volunteerlist.php?sort=Comments'>Triage Comments</a></th>
+								<th><a href='volunteerlist.php?sort=VolunteerStatus'>Volunteer Status</a></th>
+								<th><a href='volunteerlist.php?sort=DateAndTime'>Date Submitted</a></th>
+								<th><a href='volunteerlist.php?sort=WorkshopAttended'>Workshop</a></th>
+								<th><a href='volunteerlist.php?sort=WorkshopDate'>Workshop Date</a></th>
+								<th><a href='volunteerlist.php?sort=DateActivated'>Date Activated</a></th>
+								<th><a href='volunteerlist.php?sort=FullName'>Full Name</a></th>
+								<th><a href='volunteerlist.php?sort=Address'>Complete Address</a></th>
+								<th><a href='volunteerlist.php?sort=Email'>Email</a></th>
+								<th><a href='volunteerlist.php?sort=Phone1'>Phone1</a></th>
+								<th><a href='volunteerlist.php?sort=Phone2'>Phone2</a></th>
+								<th><a href='volunteerlist.php?sort=PreferedContact'>Prefered Contact</a></th>
+								<th><a href='volunteerlist.php?sort=contactemail'>Prefered Email</a></th>
+								<th><a href='volunteerlist.php?sort=contactphone1'>Prefered Phone1</a></th>
+								<th><a href='volunteerlist.php?sort=contactphone2'>Prefered Phone2</a></th>
+								<th><a href='volunteerlist.php?sort=TypeOfWork'>Type Of Work</a></th>
+								<th><a href='volunteerlist.php?sort=transporting'>Transporter</a></th>
+								<th><a href='volunteerlist.php?sort=helptrap'>Trapper</a></th>
+								<th><a href='volunteerlist.php?sort=helpeducate'>Educator</a></th>
+								<th><a href='volunteerlist.php?sort=usingphone'>Triage</a></th>
+								<th><a href='volunteerlist.php?sort=other'>Other</a></th>
+								<th><a href='volunteerlist.php?sort=OtherTasks'>Other Tasks Details</a></th>
+								<th><a href='volunteerlist.php?sort=PastWorkExp'>Past Experience</a></th>
+								<th><a href='volunteerlist.php?sort=UnknownNameColumn'>Unknown</a></th>
+								<th><a href='volunteerlist.php?sort=ResponseDate'>Response Date</a></th>
+								<th><a href='volunteerlist.php?sort=EmailResponse'>Email Response</a></th>
+								<th><a href='volunteerlist.php?sort=BEATId'>BEAT ID</a></th>					
+								<th><a href='volunteerlist.php?sort=BEATName'>BEAT Name</a></th>
+								<th><a href='volunteerlist.php?sort=BEATGeneralArea'>BEAT Gen. Area</a></th>
+								<th><a href='volunteerlist.php?sort=BEATZipCodes'>BEAT Zip Code</a></th>
+								<th><a href='volunteerlist.php?sort=BEATTrainDate'>BEAT Train Date</a></th>
+								<th><a href='volunteerlist.php?sort=BEATMembers'>BEAT Member</a></th>
+								<th><a href='volunteerlist.php?sort=BEATMembersPhone'>BEAT Member Phone</a></th>
+								<th><a href='volunteerlist.php?sort=BEATMemberEmails'>BEAT Member Email</a></th>
+								<th><a href='volunteerlist.php?sort=BEATType'>BEAT Type</a></th>
+								<th><a href='volunteerlist.php?sort=BEATNotes'>BEAT Notes</a></th>
+								<th><a href='volunteerlist.php?sort=BEATStatus'>BEAT Status</a></th>					
+								<th><a href='volunteerlist.php?sort=TriageBEATNotes'>BEAT Triage Notes</a></th>
+							</tr>";
 							}
-						print "<tbody>";
+						print"	
+						</thead>
+						
+						<tbody>";
 
 						//while the next row (set by query) exists?
 						while($row = mysqli_fetch_row($result))
@@ -918,7 +919,7 @@
 					}
 					else
 					{
-						$query = "select * from VolunteerForm where RecordNumber='$RecordNumber1'";
+						$query = "select * from VolunteerForm where RecordNumber='$RecordNumber1' order by RecordNumber desc";
 						$result = mysqli_query($link, $query);	
 						if(mysqli_num_rows($result) == 1)//if query does nothing, then update
 						{						
@@ -1004,7 +1005,7 @@
 			}
 			else{
 				//regular search
-				$query = "select * from VolunteerForm order by $sort";
+				$query = "select * from VolunteerForm order by $sort desc";
 				$result = mysqli_query($link, $query);
 			}
 			$_SESSION['volunteertotalrecords']=mysqli_num_rows($result);
@@ -1041,45 +1042,45 @@
 								else
 								{
 									print "
-								<th><a href='volunteerlist.php?sort='RecordNumber'>ID</a></th>
-								<th><a href='volunteerlist.php?sort='Comments'>Triage Comments</a></th>
-								<th><a href='volunteerlist.php?sort='VolunteerStatus'>Volunteer Status</a></th>
-								<th><a href='volunteerlist.php?sort='DateAndTime'>Date Submitted</a></th>
-								<th><a href='volunteerlist.php?sort='WorkshopAttended'>Workshop</a></th>
-								<th><a href='volunteerlist.php?sort='WorkshopDate'>Workshop Date</a></th>
-								<th><a href='volunteerlist.php?sort='DateActivated'>Date Actived</a></th>
-								<th><a href='volunteerlist.php?sort='FullName'>Full Name</a></th>
-								<th><a href='volunteerlist.php?sort='Address'>Complete Address</a></th>
-								<th><a href='volunteerlist.php?sort='Email'>Email</a></th>
-								<th><a href='volunteerlist.php?sort='Phone1'>Phone1</a></th>
-								<th><a href='volunteerlist.php?sort='Phone2'>Phone2</a></th>
-								<th><a href='volunteerlist.php?sort='PreferedContact'>Prefered Contact</a></th>
-								<th><a href='volunteerlist.php?sort='contactemail'>Prefered Email</a></th>
-								<th><a href='volunteerlist.php?sort='contactphone1'>Prefered Phone1</a></th>
-								<th><a href='volunteerlist.php?sort='contactphone2'>Prefered Phone2</a></th>
-								<th><a href='volunteerlist.php?sort='TypeOfWork'>Type Of Work</a></th>
-								<th><a href='volunteerlist.php?sort='transporting'>Transporter</a></th>
-								<th><a href='volunteerlist.php?sort='helptrap'>Trapper</a></th>
-								<th><a href='volunteerlist.php?sort='helpeducate'>Educator</a></th>
-								<th><a href='volunteerlist.php?sort='usingphone'>Triage</a></th>
-								<th><a href='volunteerlist.php?sort='other'>Other</a></th>
-								<th><a href='volunteerlist.php?sort='OtherTasks'>Other Tasks Details</a></th>
-								<th><a href='volunteerlist.php?sort='PastWorkExp'>Past Experience</a></th>
-								<th><a href='volunteerlist.php?sort='UnknownNameColumn'>Unknown</a></th>
-								<th><a href='volunteerlist.php?sort='ResponseDate'>Response Date</a></th>
-								<th><a href='volunteerlist.php?sort='EmailResponse'>Email Response</a></th>
-								<th><a href='volunteerlist.php?sort='BEATId'>BEAT ID</a></th>					
-								<th><a href='volunteerlist.php?sort='BEATName'>BEAT Name</a></th>
-								<th><a href='volunteerlist.php?sort='BEATGeneralArea'>BEAT Gen. Area</a></th>
-								<th><a href='volunteerlist.php?sort='BEATZipCodes'>BEAT Zip Code</a></th>
-								<th><a href='volunteerlist.php?sort='BEATTrainDate'>BEAT Train Date</a></th>
-								<th><a href='volunteerlist.php?sort='BEATMembers'>BEAT Member</a></th>
-								<th><a href='volunteerlist.php?sort='BEATMembersPhone'>BEAT Member Phone</a></th>
-								<th><a href='volunteerlist.php?sort='BEATMemberEmails'>BEAT Member Email</a></th>
-								<th><a href='volunteerlist.php?sort='BEATType'>BEAT Type</a></th>
-								<th><a href='volunteerlist.php?sort='BEATNotes'>BEAT Notes</a></th>
-								<th><a href='volunteerlist.php?sort='BEATStatus'>BEAT Status</a></th>					
-								<th><a href='volunteerlist.php?sort='TriageBEATNotes'>BEAT Triage Notes</a></th>								
+								<th><a href='volunteerlist.php?sort=RecordNumber'>ID</a></th>
+								<th><a href='volunteerlist.php?sort=Comments'>Triage Comments</a></th>
+								<th><a href='volunteerlist.php?sort=VolunteerStatus'>Volunteer Status</a></th>
+								<th><a href='volunteerlist.php?sort=DateAndTime'>Date Submitted</a></th>
+								<th><a href='volunteerlist.php?sort=WorkshopAttended'>Workshop</a></th>
+								<th><a href='volunteerlist.php?sort=WorkshopDate'>Workshop Date</a></th>
+								<th><a href='volunteerlist.php?sort=DateActivated'>Date Actived</a></th>
+								<th><a href='volunteerlist.php?sort=FullName'>Full Name</a></th>
+								<th><a href='volunteerlist.php?sort=Address'>Complete Address</a></th>
+								<th><a href='volunteerlist.php?sort=Email'>Email</a></th>
+								<th><a href='volunteerlist.php?sort=Phone1'>Phone1</a></th>
+								<th><a href='volunteerlist.php?sort=Phone2'>Phone2</a></th>
+								<th><a href='volunteerlist.php?sort=PreferedContact'>Prefered Contact</a></th>
+								<th><a href='volunteerlist.php?sort=contactemail'>Prefered Email</a></th>
+								<th><a href='volunteerlist.php?sort=contactphone1'>Prefered Phone1</a></th>
+								<th><a href='volunteerlist.php?sort=contactphone2'>Prefered Phone2</a></th>
+								<th><a href='volunteerlist.php?sort=TypeOfWork'>Type Of Work</a></th>
+								<th><a href='volunteerlist.php?sort=transporting'>Transporter</a></th>
+								<th><a href='volunteerlist.php?sort=helptrap'>Trapper</a></th>
+								<th><a href='volunteerlist.php?sort=helpeducate'>Educator</a></th>
+								<th><a href='volunteerlist.php?sort=usingphone'>Triage</a></th>
+								<th><a href='volunteerlist.php?sort=other'>Other</a></th>
+								<th><a href='volunteerlist.php?sort=OtherTasks'>Other Tasks Details</a></th>
+								<th><a href='volunteerlist.php?sort=PastWorkExp'>Past Experience</a></th>
+								<th><a href='volunteerlist.php?sort=UnknownNameColumn'>Unknown</a></th>
+								<th><a href='volunteerlist.php?sort=ResponseDate'>Response Date</a></th>
+								<th><a href='volunteerlist.php?sort=EmailResponse'>Email Response</a></th>
+								<th><a href='volunteerlist.php?sort=BEATId'>BEAT ID</a></th>					
+								<th><a href='volunteerlist.php?sort=BEATName'>BEAT Name</a></th>
+								<th><a href='volunteerlist.php?sort=BEATGeneralArea'>BEAT Gen. Area</a></th>
+								<th><a href='volunteerlist.php?sort=BEATZipCodes'>BEAT Zip Code</a></th>
+								<th><a href='volunteerlist.php?sort=BEATTrainDate'>BEAT Train Date</a></th>
+								<th><a href='volunteerlist.php?sort=BEATMembers'>BEAT Member</a></th>
+								<th><a href='volunteerlist.php?sort=BEATMembersPhone'>BEAT Member Phone</a></th>
+								<th><a href='volunteerlist.php?sort=BEATMemberEmails'>BEAT Member Email</a></th>
+								<th><a href='volunteerlist.php?sort=BEATType'>BEAT Type</a></th>
+								<th><a href='volunteerlist.php?sort=BEATNotes'>BEAT Notes</a></th>
+								<th><a href='volunteerlist.php?sort=BEATStatus'>BEAT Status</a></th>					
+								<th><a href='volunteerlist.php?sort=TriageBEATNotes'>BEAT Triage Notes</a></th>								
 						</tr>";
 								}
 					print"


### PR DESCRIPTION
They want to see the latest records. For the sake of simplicity I made everything sorted by descending order so they don't have to do a query for it when they first come on the page. Fixed sort by column bug in adminprofile.php and volunteerlist.php.

Note:
The select column feature will go off on what ever order is already in place. Manual Query does not sort descending  unless specified. And Custom Query does not sort by descending.