### PR TITLE
Fixed exporting for FF and removed <textarea> from export

### DIFF
--- a/sacferals/js/exportExcelScript.js
+++ b/sacferals/js/exportExcelScript.js
@@ -24,14 +24,20 @@ var tableToExcel = (function() {
 	
 	//Insert html table in Excel format
     if (!table.nodeType) table = document.getElementById(table)
-    var ctx = {worksheet: name || 'Worksheet', table: excelTitle+table.innerHTML}
+	var tableBody = table.innerHTML;	
+
+	//<textarea> was causeing textboxes to show up when enable editing in excel
+	tableBody = tableBody.replace(/<\/textarea>/g, "");  //remove </textarea>
+	tableBody = tableBody.replace(/<textarea(.|\n)*?">/g, "");  //remove<textarea...>		
+    var ctx = {worksheet: name || 'Worksheet', table: excelTitle+tableBody}
 		
 	//Name Excel file
 	today = monthName[mm] + '_' + dd + '_' + yyyy;
 	var link = document.createElement("a");
-                    link.download = name+"_"+today+".xls";
-                    link.href = uri + base64(format(template, ctx));
-                    link.click();
+	document.body.appendChild(link);
+		link.download = name+"_"+today+".xls";
+		link.href = uri + base64(format(template, ctx));
+		link.click();
   }
 })()
 


### PR DESCRIPTION
Firefox won't fire off download of excel without appendChild() first. Textboxes showing up in excel when enable edit mode is on. Used regex to remove <textarea> before creating excel file.